### PR TITLE
Fix for incorrect intersection in discoverCharacteristics

### DIFF
--- a/winble.js
+++ b/winble.js
@@ -58,7 +58,7 @@ function bluetoothDeviceManager (eventEmitter) {
       .map(stripDashes)
       .value()
     const filteredCharacteristicUuids = characteristicUuids ?
-      _.intersection(characteristicUuids, filteredCharacteristicUuids) :
+      _.intersection(characteristicUuids, discoveredCharacteristicUuids) :
       discoveredCharacteristicUuids
     const returnedCharacteristicUuids =
       _.map(filteredCharacteristicUuids, characteristicUuid => ({uuid: characteristicUuid, properties: []}))


### PR DESCRIPTION
Find intersection of the uuids found and the uuids we are looking for. 

Fixes a bug that if a uuid filter was suuplied to `discoverCharacteristics` no characteristics would be discovered.
